### PR TITLE
Ensure bundlers use modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "websocket": "^1.0.26"
   },
   "module": "./esm6/index.js",
-  "main": "bundles/rx-stomp.umd.js",
+  "main": "./esm6/index.js",
   "typings": "index.d.ts",
   "sideEffects": false
 }


### PR DESCRIPTION
Ref https://github.com/stomp-js/rx-stomp/issues/224

https://www.jonathancreamer.com/how-webpack-decides-what-entry-to-load-from-a-package-json/ lays out how Webpack chooses, I guess rollup should do similar.

We want bundlers to always choose to use modules. If someone is using it as a script tag they can use the UMD. So, changing the package.json to have the following:

```JSON
  "module": "./esm6/index.js",
  "main": "./esm6/index.js",
```
