### PR TITLE
Allow subHeaders to be a callback

### DIFF
--- a/spec/unit/subscriptions.spec.ts
+++ b/spec/unit/subscriptions.spec.ts
@@ -221,6 +221,14 @@ describe('Subscribe & Publish', () => {
       expect(subSpy.calls.argsFor(0)[2]).toEqual(subHeaders);
     });
 
+    it('should send subscription headers returned by a function', () => {
+      const sub = rxStomp
+        .watch({ destination: queueName, subHeaders: () => subHeaders })
+        .subscribe(() => {});
+
+      expect(subSpy.calls.argsFor(0)[2]).toEqual(subHeaders);
+    });    
+
     it('should use passed unsubscription headers', () => {
       const sub = rxStomp
         .watch({ destination: queueName, unsubHeaders })

--- a/src/i-watch-params.ts
+++ b/src/i-watch-params.ts
@@ -13,8 +13,22 @@ export interface IWatchParams {
 
   /**
    * Subscription headers, defaults to `{}`
+   * 
+   * If header information can change over time and you are allowing automatic resubscriptions,
+   * consider using a callback as the value rather than a string literal.
+   *
+   * ```typescript
+   *              const subHeadersCallback = () => {
+   *                  return {bye: 'world'};
+   *              };
+   *              const sub = rxStomp.watch({ destination: queueName, subHeaders: subHeadersCallback})
+   *                                 .subscribe((message) => {
+   *                                    // handle message
+   *                                 });
+   *              // The subHeadersCallback will be invoked before every (re)subscription.
+   * ```
    */
-  readonly subHeaders?: StompHeaders;
+  readonly subHeaders?: StompHeaders | (() => StompHeaders);
 
   /**
    * Headers to be passed while unsubscribing, defaults to `{}`.

--- a/src/rx-stomp.ts
+++ b/src/rx-stomp.ts
@@ -506,16 +506,20 @@ export class RxStomp {
 
       if (params.subscribeOnlyOnce) {
         connectedPre$ = connectedPre$.pipe(take(1));
-      }
+      }    
 
       stompConnectedSubscription = connectedPre$.subscribe(() => {
         this._debug(`Will subscribe to ${params.destination}`);
+        let subHeaders = params.subHeaders;
+        if (typeof subHeaders === 'function') {
+          subHeaders = subHeaders();
+        }          
         stompSubscription = this._stompClient.subscribe(
           params.destination,
           (message: IMessage) => {
             messages.next(message);
           },
-          params.subHeaders
+          subHeaders
         );
       });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,7 @@ const config = {
         test: /\.tsx?$/,
         loader: 'awesome-typescript-loader',
         exclude: /node_modules/,
-        query: {
+        options: {
           declaration: false,
         },
       },


### PR DESCRIPTION
This is the fix to issue https://github.com/stomp-js/rx-stomp/issues/298

Without this, a stale value can be passed through a header during an
automatic resubscribe

I am moving the version with this MR to 1.1.0 as this should be considered
a non-breaking feature addition.