### PR TITLE
RPC issue with custom reply quque

### DIFF
--- a/spec/helpers/helpers.ts
+++ b/spec/helpers/helpers.ts
@@ -40,3 +40,6 @@ export function forceDisconnectAndEnsure(rxStomp: RxStomp, done: () => void) {
       });
   });
 }
+
+export const wait = (timeToDelay: number) =>
+  new Promise(resolve => setTimeout(resolve, timeToDelay));

--- a/spec/unit/rpc.spec.ts
+++ b/spec/unit/rpc.spec.ts
@@ -1,19 +1,41 @@
 // These are likely to fail on any broker other than RabbitMQ
 // Works with ActiveMQ, with special init function
 
-import 'jasmine';
+import "jasmine";
 
-import { Message } from '@stomp/stompjs';
-import { UUID } from 'angular2-uuid';
+import { Message } from "@stomp/stompjs";
+import { UUID } from "angular2-uuid";
 
-import { RxStomp, RxStompRPC } from '../../src';
+import { RxStomp, RxStompRPC } from "../../src";
 
-import { generateBinaryData } from '../helpers/content-helpers';
-import { ensureRxStompConnected } from '../helpers/helpers';
-import { rxStompFactory } from '../helpers/rx-stomp-factory';
+import { generateBinaryData } from "../helpers/content-helpers";
+import { ensureRxStompConnected } from "../helpers/helpers";
+import { rxStompFactory } from "../helpers/rx-stomp-factory";
 
-describe('RPC', () => {
-  const myRPCEndPoint = '/topic/echo';
+function startRPCServer(rxStomp: RxStomp, myRPCEndPoint: string, done: () => void) {
+  const receiptId = UUID.UUID();
+
+  rxStomp
+    .watch(myRPCEndPoint, { receipt: receiptId })
+    .subscribe((message: Message) => {
+      const replyTo = message.headers["reply-to"];
+      const correlationId = message.headers["correlation-id"];
+      const incomingMessage = message.binaryBody;
+
+      rxStomp.publish({
+        destination: replyTo,
+        binaryBody: incomingMessage,
+        headers: { "correlation-id": correlationId }
+      });
+    });
+
+  rxStomp.watchForReceipt(receiptId, () => {
+    done();
+  });
+}
+
+describe("RPC", () => {
+  const myRPCEndPoint = "/topic/echo";
 
   let rxStomp: RxStomp;
   let rxStompRPC: RxStompRPC;
@@ -25,32 +47,12 @@ describe('RPC', () => {
     ensureRxStompConnected(rxStomp, done);
   });
 
-  beforeAll(done => {
-    const receiptId = UUID.UUID();
+  beforeAll(done => startRPCServer(rxStomp, myRPCEndPoint, done));
 
-    rxStomp
-      .watch(myRPCEndPoint, { receipt: receiptId })
-      .subscribe((message: Message) => {
-        const replyTo = message.headers['reply-to'];
-        const correlationId = message.headers['correlation-id'];
-        const incomingMessage = message.binaryBody;
-
-        rxStomp.publish({
-          destination: replyTo,
-          binaryBody: incomingMessage,
-          headers: { 'correlation-id': correlationId },
-        });
-      });
-
-    rxStomp.watchForReceipt(receiptId, () => {
-      done();
-    });
-  });
-
-  it('Simple RPC', done => {
+  it("Simple RPC", done => {
     // Watch for RPC response
 
-    const msg = 'Hello';
+    const msg = "Hello";
     rxStompRPC
       .rpc({ destination: myRPCEndPoint, body: msg })
       .subscribe((message: Message) => {
@@ -59,22 +61,22 @@ describe('RPC', () => {
       });
   });
 
-  it('RPC with custom correlation-id', done => {
+  it("RPC with custom correlation-id", done => {
     // Watch for RPC response
 
-    const msg = 'Hello';
+    const msg = "Hello";
     const customCorrelationId = `custom-${UUID.UUID()}`;
-    const headers = { 'correlation-id': customCorrelationId };
+    const headers = { "correlation-id": customCorrelationId };
     rxStompRPC
       .rpc({ destination: myRPCEndPoint, body: msg, headers })
       .subscribe((message: Message) => {
         expect(message.body).toEqual(msg);
-        expect(message.headers['correlation-id']).toEqual(customCorrelationId);
+        expect(message.headers["correlation-id"]).toEqual(customCorrelationId);
         done();
       });
   });
 
-  it('RPC with binary payload', done => {
+  it("RPC with binary payload", done => {
     // Watch for RPC response
 
     const binaryMsg = generateBinaryData(1);
@@ -86,14 +88,14 @@ describe('RPC', () => {
       });
   });
 
-  it('Should not leak', done => {
+  it("Should not leak", done => {
     const numSubscribers = () => {
       return rxStomp.unhandledMessage$.observers.length;
     };
 
     const origNumSubcribers = numSubscribers();
 
-    const msg = 'Hello';
+    const msg = "Hello";
     // Watch for RPC response
     rxStompRPC
       .rpc({ destination: myRPCEndPoint, body: msg })
@@ -106,5 +108,58 @@ describe('RPC', () => {
       });
 
     expect(numSubscribers()).toBe(origNumSubcribers + 1);
+  });
+});
+
+describe("Custom Queue RPC", () => {
+  const myRPCEndPoint = "/topic/echo";
+
+  let rxStomp: RxStomp;
+  let rxStompRPC: RxStompRPC;
+
+  const stompRPCConfig = {
+    // A name unique across all clients
+    replyQueueName: `/queue/replies-${UUID.UUID()}`,
+
+    // Simply subscribe, you would need to secure by adding broker specific options
+    setupReplyQueue: (replyQueueName: string, rxStomp1: RxStomp) => {
+      return rxStomp1.watch(replyQueueName, {
+        durable: 'false',
+        'auto-delete': 'true',
+        'exclusive': 'true'
+      });
+    },
+  };
+
+  // Wait till RxStomp is actually connected
+  beforeAll(done => {
+    rxStomp = rxStompFactory();
+    rxStompRPC = new RxStompRPC(rxStomp, stompRPCConfig);
+    ensureRxStompConnected(rxStomp, done);
+  });
+
+  beforeAll(done => startRPCServer(rxStomp, myRPCEndPoint, done));
+
+  function rpcCallHelper(message: string): Promise<Message> {
+    return rxStompRPC
+      .rpc({ destination: myRPCEndPoint, body: message })
+      .toPromise();
+  }
+
+  it("Multiple RPC requests", async () => {
+    // Watch for RPC response
+
+    const msg01 = "Hello";
+    const msg02 = "World";
+    const msg03 = "Hello World";
+
+    const reply01 = await rpcCallHelper(msg01);
+    expect(reply01.body).toEqual(msg01);
+
+    const reply02 = await rpcCallHelper(msg02);
+    expect(reply02.body).toEqual(msg02);
+
+    const reply03 = await rpcCallHelper(msg03);
+    expect(reply03.body).toEqual(msg03);
   });
 });

--- a/spec/unit/rpc.spec.ts
+++ b/spec/unit/rpc.spec.ts
@@ -1,5 +1,5 @@
-// These are likely to fail on any broker other than RabbitMQ
-// Works with ActiveMQ, with special init function
+// Tests under 'RPC' group are likely to fail on any broker other than RabbitMQ
+// The tests under 'Custom Queue RPC' should work on every broker
 
 import "jasmine";
 
@@ -9,37 +9,84 @@ import { UUID } from "angular2-uuid";
 import { RxStomp, RxStompRPC } from "../../src";
 
 import { generateBinaryData } from "../helpers/content-helpers";
-import { ensureRxStompConnected } from "../helpers/helpers";
+import { ensureRxStompConnected, wait } from "../helpers/helpers";
 import { rxStompFactory } from "../helpers/rx-stomp-factory";
 
-function startRPCServer(rxStomp: RxStomp, myRPCEndPoint: string, done: () => void) {
+const myRPCEndPoint = '/topic/echo';
+
+let rxStomp: RxStomp;
+let rxStompRPC: RxStompRPC;
+
+const startRPCServer = (done: () => void) => {
   const receiptId = UUID.UUID();
 
   rxStomp
     .watch(myRPCEndPoint, { receipt: receiptId })
     .subscribe((message: Message) => {
-      const replyTo = message.headers["reply-to"];
-      const correlationId = message.headers["correlation-id"];
+      const replyTo = message.headers['reply-to'];
+      const correlationId = message.headers['correlation-id'];
       const incomingMessage = message.binaryBody;
 
       rxStomp.publish({
         destination: replyTo,
         binaryBody: incomingMessage,
-        headers: { "correlation-id": correlationId }
+        headers: { 'correlation-id': correlationId },
       });
     });
 
   rxStomp.watchForReceipt(receiptId, () => {
     done();
   });
-}
+};
 
-describe("RPC", () => {
-  const myRPCEndPoint = "/topic/echo";
+const rpcCallHelper = (message: string): Promise<Message> =>
+  rxStompRPC.rpc({ destination: myRPCEndPoint, body: message }).toPromise();
 
-  let rxStomp: RxStomp;
-  let rxStompRPC: RxStompRPC;
+const simpleRPCRetestTest = async () => {
+  const msg01 = 'Hello';
 
+  const reply01 = await rpcCallHelper(msg01);
+  expect(reply01.body).toEqual(msg01);
+};
+
+const multiRPCRetestsTest = async () => {
+  const msg01 = 'Hello';
+  const msg02 = 'World';
+  const msg03 = 'Hello World';
+
+  const reply01 = await rpcCallHelper(msg01);
+  expect(reply01.body).toEqual(msg01);
+
+  const reply02 = await rpcCallHelper(msg02);
+  expect(reply02.body).toEqual(msg02);
+
+  const reply03 = await rpcCallHelper(msg03);
+  expect(reply03.body).toEqual(msg03);
+};
+
+const rpcWithCustomCorrelationId = async () => {
+  const msg = 'Hello';
+  const customCorrelationId = `custom-${UUID.UUID()}`;
+  const headers = { 'correlation-id': customCorrelationId };
+
+  const reply = await rxStompRPC
+    .rpc({ destination: myRPCEndPoint, body: msg, headers })
+    .toPromise();
+
+  expect(reply.body).toEqual(msg);
+  expect(reply.headers['correlation-id']).toEqual(customCorrelationId);
+};
+
+const rpcWithBinayPayload = async () => {
+  const binaryMsg = generateBinaryData(1);
+  const message = await rxStompRPC
+    .rpc({ destination: myRPCEndPoint, binaryBody: binaryMsg })
+    .toPromise();
+
+  expect(message.binaryBody.toString()).toEqual(binaryMsg.toString());
+};
+
+describe('RPC', () => {
   // Wait till RxStomp is actually connected
   beforeAll(done => {
     rxStomp = rxStompFactory();
@@ -47,76 +94,35 @@ describe("RPC", () => {
     ensureRxStompConnected(rxStomp, done);
   });
 
-  beforeAll(done => startRPCServer(rxStomp, myRPCEndPoint, done));
+  beforeAll(done => startRPCServer(done));
 
-  it("Simple RPC", done => {
-    // Watch for RPC response
+  it('Simple RPC', simpleRPCRetestTest);
+  it('Multiple RPC requests', multiRPCRetestsTest);
+  it('RPC with custom correlation-id', rpcWithCustomCorrelationId);
+  it('RPC with binary payload', rpcWithBinayPayload);
 
-    const msg = "Hello";
-    rxStompRPC
-      .rpc({ destination: myRPCEndPoint, body: msg })
-      .subscribe((message: Message) => {
-        expect(message.body).toEqual(msg);
-        done();
-      });
-  });
-
-  it("RPC with custom correlation-id", done => {
-    // Watch for RPC response
-
-    const msg = "Hello";
-    const customCorrelationId = `custom-${UUID.UUID()}`;
-    const headers = { "correlation-id": customCorrelationId };
-    rxStompRPC
-      .rpc({ destination: myRPCEndPoint, body: msg, headers })
-      .subscribe((message: Message) => {
-        expect(message.body).toEqual(msg);
-        expect(message.headers["correlation-id"]).toEqual(customCorrelationId);
-        done();
-      });
-  });
-
-  it("RPC with binary payload", done => {
-    // Watch for RPC response
-
-    const binaryMsg = generateBinaryData(1);
-    rxStompRPC
-      .rpc({ destination: myRPCEndPoint, binaryBody: binaryMsg })
-      .subscribe((message: Message) => {
-        expect(message.binaryBody.toString()).toEqual(binaryMsg.toString());
-        done();
-      });
-  });
-
-  it("Should not leak", done => {
+  it('Should not leak', async () => {
     const numSubscribers = () => {
       return rxStomp.unhandledMessage$.observers.length;
     };
 
-    const origNumSubcribers = numSubscribers();
+    const origNumSubscribers = numSubscribers();
 
-    const msg = "Hello";
-    // Watch for RPC response
-    rxStompRPC
-      .rpc({ destination: myRPCEndPoint, body: msg })
-      .subscribe((message: Message) => {
-        expect(message.body).toEqual(msg);
-        setTimeout(() => {
-          expect(numSubscribers()).toBe(origNumSubcribers);
-          done();
-        }, 0);
-      });
+    const messagePromise = rxStompRPC
+      .rpc({ destination: myRPCEndPoint, body: 'Hello' })
+      .toPromise();
 
-    expect(numSubscribers()).toBe(origNumSubcribers + 1);
+    // Just after initiating the request, teh count should go up by 1
+    expect(numSubscribers()).toBe(origNumSubscribers + 1);
+
+    // After receiving the response, the count should go back
+    await messagePromise;
+    await wait(0);
+    expect(numSubscribers()).toBe(origNumSubscribers);
   });
 });
 
-describe("Custom Queue RPC", () => {
-  const myRPCEndPoint = "/topic/echo";
-
-  let rxStomp: RxStomp;
-  let rxStompRPC: RxStompRPC;
-
+describe('Custom Queue RPC', () => {
   const stompRPCConfig = {
     // A name unique across all clients
     replyQueueName: `/queue/replies-${UUID.UUID()}`,
@@ -126,7 +132,7 @@ describe("Custom Queue RPC", () => {
       return rxStomp1.watch(replyQueueName, {
         durable: 'false',
         'auto-delete': 'true',
-        'exclusive': 'true'
+        exclusive: 'true',
       });
     },
   };
@@ -138,28 +144,10 @@ describe("Custom Queue RPC", () => {
     ensureRxStompConnected(rxStomp, done);
   });
 
-  beforeAll(done => startRPCServer(rxStomp, myRPCEndPoint, done));
+  beforeAll(done => startRPCServer(done));
 
-  function rpcCallHelper(message: string): Promise<Message> {
-    return rxStompRPC
-      .rpc({ destination: myRPCEndPoint, body: message })
-      .toPromise();
-  }
-
-  it("Multiple RPC requests", async () => {
-    // Watch for RPC response
-
-    const msg01 = "Hello";
-    const msg02 = "World";
-    const msg03 = "Hello World";
-
-    const reply01 = await rpcCallHelper(msg01);
-    expect(reply01.body).toEqual(msg01);
-
-    const reply02 = await rpcCallHelper(msg02);
-    expect(reply02.body).toEqual(msg02);
-
-    const reply03 = await rpcCallHelper(msg03);
-    expect(reply03.body).toEqual(msg03);
-  });
+  it('Simple RPC', simpleRPCRetestTest);
+  it('Multiple RPC requests', multiRPCRetestsTest);
+  it('RPC with custom correlation-id', rpcWithCustomCorrelationId);
+  it('RPC with binary payload', rpcWithBinayPayload);
 });


### PR DESCRIPTION
It was an interesting issue. The standard `RxStomp.watch unsubscribes when there are no consumers. To avoid this a dummy subscription is created and maintained.

This PR also adds more rigorous test cases for custom reply queue mode.