### PR TITLE
Documentation fix for RxStompConfig 

### DIFF
--- a/src/rx-stomp-config.ts
+++ b/src/rx-stomp-config.ts
@@ -83,14 +83,14 @@ export class RxStompConfig {
   /**
    * Automatically reconnect with delay in milliseconds, set to 0 to disable.
    *
-   * Maps to: [Client#reconnectDelay]{@Client#reconnectDelay}
+   * Maps to: [Client#reconnectDelay]{@link Client#reconnectDelay}
    */
   public reconnectDelay?: number;
 
   /**
    * Incoming heartbeat interval in milliseconds. Set to 0 to disable.
    *
-   * Maps to: [Client#heartbeatIncoming]{@Client#heartbeatIncoming}
+   * Maps to: [Client#heartbeatIncoming]{@link Client#heartbeatIncoming}
    */
   public heartbeatIncoming?: number;
 

--- a/src/rx-stomp-config.ts
+++ b/src/rx-stomp-config.ts
@@ -160,7 +160,7 @@ export class RxStompConfig {
    * This can be used to reliably fetch credentials, access token etc. from some other service
    * in an asynchronous way.
    *
-   * As of 0.3.5, this callback will receive [RxStomp](@link RxStomp) as parameter.
+   * As of 0.3.5, this callback will receive [RxStomp]{@link RxStomp} as parameter.
    *
    * Maps to: [Client#beforeConnect]{@link Client#beforeConnect}
    */

--- a/src/rx-stomp-config.ts
+++ b/src/rx-stomp-config.ts
@@ -150,7 +150,7 @@ export class RxStompConfig {
    * Callback, invoked on before a connection connection to the STOMP broker.
    *
    * You can change configuration of the rxStomp, which will impact the immediate connect.
-   * It is valid to call [RxStomp#decativate]{@link RxStomp#deactivate} in this callback.
+   * It is valid to call [RxStomp#deactivate]{@link RxStomp#deactivate} in this callback.
    *
    * As of version 0.1.1, this callback can be
    * [async](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function)


### PR DESCRIPTION
Hello, here is little error found into doc page https://stomp-js.github.io/api-docs/latest/classes/RxStompConfig.html :

"call `RxStomp#decativate` in this callback" : 

![Capture d’écran de 2022-02-09 15-28-13](https://user-images.githubusercontent.com/25805069/153221863-346c360b-b62b-42b3-853e-c8c3e3025bf9.png)

"will receive `[RxStomp](@link RxStomp)` as parameter." : 

![Capture d’écran de 2022-02-09 15-37-17](https://user-images.githubusercontent.com/25805069/153223245-f23026f4-9604-4570-a2d9-9b1284675b98.png)

"Maps to: `[Client#heartbeatIncoming]{@Client#heartbeatIncoming}`" : 

![Capture d’écran de 2022-02-09 15-42-14](https://user-images.githubusercontent.com/25805069/153224263-d37934a6-ae52-493e-ac4b-6528097f7f6e.png)

"Maps to: `[Client#reconnectDelay]{@Client#reconnectDelay}`" : 

![Capture d’écran de 2022-02-09 15-43-22](https://user-images.githubusercontent.com/25805069/153224422-21bb24a7-9bc6-4c28-b31b-b274bc9aaad7.png)

Here is a little PR to fix it