### PR TITLE
Relax UUID peerDependency to >=9.0.0 <15.0.0

### DIFF
--- a/Change-log.md
+++ b/Change-log.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- Extended `uuid` peer dependency range to `>=9.0.0 <15.0.0` to resolve npm audit advisory [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (missing buffer bounds check in `uuid` v3/v5/v6). Only `v4()` is used internally, no API changes.
 - Reverted PR [#602](https://github.com/stomp-js/rx-stomp/pull/602), fixes [#614](https://github.com/stomp-js/rx-stomp/issues/614).
 
 ## 2.2.0 (2025-09-23)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stomp/rx-stomp",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stomp/rx-stomp",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@chiragrupani/karma-chromium-edge-launcher": "^2.4.1",
@@ -33,7 +33,7 @@
       "peerDependencies": {
         "@stomp/stompjs": "^7.2.0",
         "rxjs": "^7.2.0",
-        "uuid": ">=9.0.0 <12.0.0"
+        "uuid": ">=9.0.0 <15.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "@stomp/stompjs": "^7.2.0",
     "rxjs": "^7.2.0",
-    "uuid": ">=9.0.0 <12.0.0"
+    "uuid": ">=9.0.0 <15.0.0"
   },
   "devDependencies": {
     "@chiragrupani/karma-chromium-edge-launcher": "^2.4.1",


### PR DESCRIPTION
Target issue: https://github.com/stomp-js/rx-stomp/issues/640

Extends the `uuid` peer dependency range from `>=9.0.0 <12.0.0` to `>=9.0.0 <15.0.0`
to allow uuid v14.x, resolving the npm audit advisory GHSA-w5hq-g745-h8pq.

- **Affected range**: `uuid < 14.0.0` (missing buffer bounds check in v3/v5/v6)
- With the current `<12.0.0` cap, npm resolves `uuid@11.x` which triggers the advisory

**Note**: I didn't bump the project version, not sure if it's up to the maintainer
